### PR TITLE
Fix formatting issues & issue with temp directory

### DIFF
--- a/ami_management/_distribute-to-single-region
+++ b/ami_management/_distribute-to-single-region
@@ -12,29 +12,31 @@ region=$1
 source_region=$2
 ami_id=$3
 name=$4
-    
+
 echo -n "$region: "
-new_ami_id=$(aws ec2 copy-image --region $region --source-region $source_region --source-image-id $ami_id --name "$name")
+new_ami_id=$(aws ec2 copy-image --output text --region $region --source-region $source_region --source-image-id $ami_id --name "$name")
 while [ true ]; do
     sleep 15
     set +e
-    state=$(aws ec2 describe-images --region $region --image-id $new_ami_id --query 'Images[*].State')
+    state=$(aws ec2 describe-images --output text --region $region --image-id $new_ami_id --query 'Images[*].State')
     if [ "$state" = "available" ]; then
         break;
     fi
     echo "$region $new_ami_id: Pending..."
 done
+
 set -e
 echo "$region $new_ami_id: Making public..."
-aws ec2 modify-image-attribute --region $region --image-id $new_ami_id --launch-permission "{\"Add\": [{\"Group\":\"all\"}]}"
+aws ec2 modify-image-attribute --output text --region $region --image-id $new_ami_id --launch-permission "{\"Add\": [{\"Group\":\"all\"}]}"
 while [ true ]; do
     sleep 15
     set +e
-    public=$(aws ec2 describe-images --region $region --image-id $new_ami_id --query 'Images[*].Public')
+    public=$(aws ec2 describe-images --output text --region $region --image-id $new_ami_id --query 'Images[*].Public')
     if [ "$public" = "True" ]; then
         break;
     fi
     echo "$region $new_ami_id: Waiting for public..."
 done
+
 set -e
 echo "$region $new_ami_id: Done."

--- a/ami_management/delete-matching-ami-from-all-regions
+++ b/ami_management/delete-matching-ami-from-all-regions
@@ -13,7 +13,7 @@ name=$1
 
 for region in $(aws ec2 describe-regions --output text --query "Regions[*].RegionName"); do
     echo -n "$region: "
-    ami_id=$(aws ec2 describe-images --region $region --owners self --filters "Name=name,Values=$name" --query 'Images[*].ImageId')
+    ami_id=$(aws ec2 describe-images --output text --region $region --owners self --filters "Name=name,Values=$name" --query 'Images[*].ImageId')
     if [ "$ami_id" == "" ]; then
         echo "No AMI by that name."
         continue
@@ -28,7 +28,7 @@ while [ true ]; do
     still_waiting=0
     for region in $(aws ec2 describe-regions --output text --query "Regions[*].RegionName"); do
         echo -n "Checking for AMI still lingering around in $region: "
-        ami_id=$(aws ec2 describe-images --region $region --owners self --filters "Name=name,Values=$name" --query 'Images[*].ImageId')
+        ami_id=$(aws ec2 describe-images --output text --region $region --owners self --filters "Name=name,Values=$name" --query 'Images[*].ImageId')
         if [ "$ami_id" == "" ]; then
             echo "Gone."
         else

--- a/ami_management/distribute-ami-to-all-regions
+++ b/ami_management/distribute-ami-to-all-regions
@@ -8,15 +8,15 @@ fi
 set -u
 set -e
 
+script_dir=$(cd $(dirname $0) && pwd)
 source_region=$1
 ami_id=$2
 
-name=$(aws ec2 describe-images --image-ids $ami_id --query 'Images[*].Name')
+name=$(aws ec2 describe-images --output text --region $source_region --image-ids $ami_id --query 'Images[*].Name')
 echo "AMI: $name"
 
 for region in $(aws ec2 describe-regions --output text --query "Regions[*].RegionName"); do
-    if [ "$region" == "$source_region" ]; then
-        continue
+    if [ "$region" != "$source_region" ]; then
+      ${script_dir}/_distribute-to-single-region $region $source_region $ami_id "$name" &
     fi
-    ./_distribute-to-single-region $region $source_region $ami_id "$name" &
 done

--- a/playbooks/build-ami.yml
+++ b/playbooks/build-ami.yml
@@ -30,6 +30,7 @@
     # TODO: handle case where AMI name already exists
     - name: Register AMI from
       command: aws ec2 register-image
+               --region {{ ec2_region }}
                --name '{{ ami_name }}'
                --description '{{ ami_description }}'
                --architecture {{ ami_architecture }}
@@ -51,8 +52,6 @@
         # vyos-build-ami-git-rev: "{{ local_git_revision.stdout }}"
           build_user: "{{ ansible_user_id }}"
           build_controller_host: "{{ ansible_hostname }}"
-
-    - fail:
 
     - name: Find local git revision
       command: git rev-parse HEAD

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -1,6 +1,6 @@
 key_pair_name: vyos-build-ami
 ec2_region: us-east-1
-temp_folder: .tmp
+temp_folder: "{{ playbook_dir }}/files/ssh-keys"
 key_pair_file: "{{ temp_folder }}/{{ key_pair_name }}.pem"
 instance_type: t2.medium
 placeholder: vyos-build-ami


### PR DESCRIPTION
- Ensure AWS cli uses `--output text` for consistent formatting, regardless of user's default configuration (e.g. `json`)
- Use absolute path for temp directory, so build script can be invoked from alternate CWD