### PR TITLE
Fix version_string extraction command

### DIFF
--- a/playbooks/build-disk.yml
+++ b/playbooks/build-disk.yml
@@ -89,7 +89,7 @@
         state: mounted
 
     - name: Read version string from iso packages
-      shell: cat {{ CD_SQUASH_ROOT }}/opt/vyatta/etc/version | awk '{print $2}' | tr + -
+      shell: cat {{ CD_SQUASH_ROOT }}/opt/vyatta/etc/version | awk '/Version/ {print $2"-"$3}'
       register: version_string
 
     - name: Debug version string as read from ISO


### PR DESCRIPTION
I ran into this error while running the playbook:

```
fatal: [54.89.93.32]: FAILED! => {
    "changed": true, 
    "cmd": [
        "cp", 
        "-p", 
        "/mnt/cdrom/live/filesystem.squashfs", 
        "/mnt/wroot/boot/VyOS", 
        "VyOS", 
        "2017/VyOS", 
        "VyOS", 
        "2017.squashfs"
    ], 
    "delta": "0:00:00.019868", 
    "end": "2018-05-16 20:16:49.497827", 
    "invocation": {
        "module_args": {
            "_raw_params": "cp -p /mnt/cdrom/live/filesystem.squashfs /mnt/wroot/boot/VyOS\nVyOS\n2017/VyOS\nVyOS\n2017.squashfs", 
            "_uses_shell": false, 
            "chdir": null, 
            "creates": "/mnt/wroot/boot/VyOS\nVyOS\n2017/VyOS\nVyOS\n2017.squashfs", 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "msg": "non-zero return code", 
    "rc": 1, 
    "start": "2018-05-16 20:16:49.477959", 
    "stderr": "cp: target ‘2017.squashfs’ is not a directory", 
    "stderr_lines": [
        "cp: target ‘2017.squashfs’ is not a directory"
    ], 
    "stdout": "", 
    "stdout_lines": []
}
```

The important bits are:

```
cp -p /mnt/cdrom/live/filesystem.squashfs /mnt/wroot/boot/VyOS\nVyOS\n2017/VyOS\nVyOS\n2017.squashfs
```

where the error was:

```
cp: target ‘2017.squashfs’ is not a directory
```

The problem here is obviously the carriage returns in the path. That was happening due to the shell command being used to extract the `version_string` that's used:

```
cat {{ CD_SQUASH_ROOT }}/opt/vyatta/etc/version | awk '{print $2}' | tr + -
```

SSH'ing into the VM, this was the state of affairs:

```
admin@ip-172-31-42-220:~$ cat /mnt/cdsquash/opt/vyatta/etc/version
Version:      VyOS 1.1.8
Description:  VyOS 1.1.8 (helium)
Copyright:    2017 VyOS maintainers and contributors
admin@ip-172-31-42-220:~$ cat /mnt/cdsquash/opt/vyatta/etc/version | awk '{print $2}' | tr + -
VyOS
VyOS
2017
```

My fix solved the issue and you can see the output here:

```
admin@ip-172-31-42-220:~$ cat /mnt/cdsquash/opt/vyatta/etc/version | awk '/Version/ {print $2"-"$3}'
VyOS-1.1.8
```