### PR TITLE
V1.1.x

### DIFF
--- a/playbooks/build-disk.yml
+++ b/playbooks/build-disk.yml
@@ -29,7 +29,7 @@
       uri:
         url: "{{ vyos_iso_url }}.asc"
         dest: "{{ vyos_iso_local }}.asc"
-        status_code: 200,404,403
+        status_code: 200,404,403,304
       register: gpg_uri
 
     - name: Download VyOS ISO release
@@ -79,33 +79,23 @@
     - name: Debug version string as read from ISO
       debug: msg="This is version {{ version_string.stdout }}"
 
-    # ---- Prepare EBS disk ----
-    # All the parted stuff may be replaced when this PR is merged
-    # https://github.com/ansible/ansible-modules-extras/pull/2518
-    - name: Check if EBS disk has already been modified by this playbook
-      shell: parted --script {{ volume_drive }} print || true
-      register: parted_print
-      changed_when: False
+    - name: Create root partition
+      parted:
+        device: "{{ volume_drive }}"
+        label: msdos
+        part_start: 0%
+        part_end: 100%
+        state: present
+        number: 1
 
-    - name: Create a disk label
-      command: parted --script {{ volume_drive }} mklabel msdos
-      when: "parted_print is defined and
-            parted_print.stdout.startswith('Error: {{ volume_drive }}: unrecognised disk label')"
-
-    - name: Make a root partition using the full disk and optimal alignment
-      command: parted --script --align optimal {{ volume_drive }} mkpart primary 0% 100%
-      when: parted_print is defined and
-            parted_print.stdout.find('primary') == -1
+    # call "set 1 boot" multiple times is ok
+    - name: Make {{ volume_drive }} bootable
+      command: parted --script {{ volume_drive }} set 1 boot
 
     - name: Create a filesystem on root partition
       filesystem:
         fstype: "{{ ROOT_FSTYPE }}"
         device: "{{ ROOT_PARTITION }}"
-
-    - name: Make {{ volume_drive }} bootable
-      command: parted --script {{ volume_drive }} set 1 boot
-      when: parted_print is defined and
-            parted_print.stdout.find('boot') == -1
 
     - name: Mount root partition
       mount:
@@ -120,6 +110,12 @@
         path: "{{ WRITE_ROOT }}/boot/{{ version_string.stdout }}/live-rw"
         state: directory
       register: RW_DIR
+
+    - name: Create workdir directory
+      file:
+        path: "{{ WRITE_ROOT }}/boot/{{ version_string.stdout }}/live-workdir"
+        state: directory
+      register: WORK_DIR
 
     - name: Copy squashfs image from ISO to root partition
       command: cp -p {{ SQUASHFS_IMAGE }} {{ WRITE_ROOT }}/boot/{{ version_string.stdout }}/{{ version_string.stdout }}.squashfs
@@ -144,7 +140,7 @@
         name: "{{ INSTALL_ROOT }}"
         src: overlayfs
         fstype: overlayfs
-        opts: "noatime,upperdir={{ RW_DIR.path }},lowerdir={{ READ_ROOT }}"
+        opts: "noatime,upperdir={{ RW_DIR.path }},lowerdir={{ READ_ROOT }},workdir={{ WORK_DIR.path }}"
         state: mounted
 
     # ---- Post image installation tasks ----

--- a/playbooks/build-disk.yml
+++ b/playbooks/build-disk.yml
@@ -83,14 +83,11 @@
       parted:
         device: "{{ volume_drive }}"
         label: msdos
+        flags: [boot]
         part_start: 0%
         part_end: 100%
         state: present
         number: 1
-
-    # call "set 1 boot" multiple times is ok
-    - name: Make {{ volume_drive }} bootable
-      command: parted --script {{ volume_drive }} set 1 boot
 
     - name: Create a filesystem on root partition
       filesystem:


### PR DESCRIPTION
The 1.1.x playbook is broken on several places. e.g. The ec2_vpc has been removed from latest ansible. So I can't use the whole playbook directly, now I fixed three parts of build-disk.yml:
1 add 304 status code for download vyos iso asc, if the asc exists in local file system, the uri module might get 304 return code, and the playbook would be failed. I don't know why, but let the uri module accept 304 status code will fix this issue.
2 use ansible parted module instead of parted schell command, the original parted "mklabel msdos" command might be skipped because the parted_print.stdout is
3 add workdir for the overlayfs, or overlayfs can't be mounted successful.
After apply these 3 changes, I can call build-disk.yml successful, e.g.:
copy build-disk.yml and the playbooks/templates directory to another directory, then run:
ansible-playbook -i hosts --private-key yupeng.pem -e "iso=https://downloads.vyos.io/release/1.1.8/vyos-1.1.8-amd64.iso" -e "volume_drive=/dev/xvdf" build-disk.yml

The whole playbook still doesn't work because the ec2_vpc moudle is not available in last ansible, but after apply my patch, I could create an instance manually, use the build-disk.yml to install vyos on an EBS volume, then create snapshot and ami manually.