### PR TITLE
add missing "region" parameter to some modules

### DIFF
--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -35,3 +35,4 @@
       ec2_group:
         state: absent
         group_id: "{{ security_group.group_id }}"
+        region: "{{ ec2_region }}"

--- a/playbooks/provision-instance.yml
+++ b/playbooks/provision-instance.yml
@@ -25,12 +25,14 @@
 
     - name: Find the default VPC
       ec2_vpc_net_facts:
+        region: "{{ ec2_region }}"
         filters:
           isDefault: "true"
       register: vpc_nets
 
     - name: Find the default VPC subnet
       ec2_vpc_subnet_facts:
+        region: "{{ ec2_region }}"
         filters:
           "vpc-id": "{{ vpc_nets.vpcs[0].vpc_id }}"
           defaultForAz: "true"
@@ -54,6 +56,7 @@
     - name: Look up Debian Jessie AMI
       ec2_ami_facts:
         owners: 379101102735
+        region: "{{ ec2_region }}"
         filters:
           name: "debian-jessie-amd64-hvm-*"
           architecture: "x86_64"


### PR DESCRIPTION
My attempts to build VyOS 1.2.1-S2 in us-west-2 failed without these additional region parameters. With them, I've tested and have been able to successfully build a new AMI in us-west-2.