### PR TITLE
Add support for regions not included in boto2

### DIFF
--- a/vyos-build-ami
+++ b/vyos-build-ami
@@ -31,6 +31,10 @@ fi
 
 ISO_URL=$1
 
+# Allow boto (2) to connect to new regions that aren't built-in
+# (see https://github.com/boto/boto/issues/3783#issuecomment-422990383)
+export BOTO_USE_ENDPOINT_HEURISTICS=True
+
 # Do the job
 
 cd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )


### PR DESCRIPTION
Boto2 has been looking abandoned for quite a while, and some ansible aws commands still depend on it (rather than boto3).

This pull-requests makes boto2 find regions that haven't been hardcoded into the current version (like eu-west-3).