### PR TITLE
Added support for pipenv and non-standard python configurations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+botocore = "*"
+boto3 = "*"
+boto = "*"
+
+[requires]
+python_version = "3.7"

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -8,3 +8,4 @@ volume_size: 4
 volume_drive: /dev/xvdf
 ansible_ssh_private_key_file: "{{ key_pair_file }}"
 ansible_host_key_checking: False
+ansible_python_interpreter: python


### PR DESCRIPTION
This pull-request makes this project compatible with pipenv.

It can be run with

```bash
pipenv run ./vyos-build-ami "<image_uri>"
```

I'm not sure if the changes will break regular usage, but they shouldn't as I believe it will default to use the default PATH `python`, instead of /bin/python (which was breaking for me on Mac OS)