### PR TITLE
Update sources.list

### DIFF
--- a/playbooks/files/sources.list
+++ b/playbooks/files/sources.list
@@ -1,2 +1,2 @@
-deb http://archive.debian.org/debian/ jessie main non-free contrib
-deb-src http://archive.debian.org/debian/ jessie main non-free contrib
+deb http://deb.debian.org/debian/ jessie main non-free contrib
+deb-src http://deb.debian.org/debian/ jessie main non-free contrib


### PR DESCRIPTION
Ansible's playbook is failing for the following reason:
"WARNING: The following packages cannot be authenticated!
  libparted2 parted
Install these packages without verification?"
More in depth investigation lead me to the error "W: GPG error: http://archive.debian.org jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717" during apt-get update
Substitute "http://archive.debian.org/debian/" with "http://deb.debian.org/debian/" in sources.list makes the process work again