### PR TITLE
Migrate to Debian Jessie

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -2,10 +2,10 @@ key_pair_name: vyos-build-ami
 ec2_region: us-east-1
 temp_folder: "{{ playbook_dir }}/files/ssh-keys"
 key_pair_file: "{{ temp_folder }}/{{ key_pair_name }}.pem"
-instance_type: t2.micro
+instance_type: t3.micro
 placeholder: vyos-build-ami
 volume_size: 4
-volume_drive: /dev/xvdf
+volume_drive: /dev/nvme1n1
 ansible_ssh_private_key_file: "{{ key_pair_file }}"
 ansible_host_key_checking: False
 ansible_python_interpreter: python

--- a/playbooks/roles/build-disk/defaults/main.yml
+++ b/playbooks/roles/build-disk/defaults/main.yml
@@ -9,9 +9,9 @@ CD_SQUASH_ROOT: /mnt/cdsquash
 SQUASHFS_IMAGE: "{{ CD_ROOT }}/live/filesystem.squashfs"
 
 ROOT_FSTYPE: ext4
-ROOT_PARTITION: "{{ volume_drive }}1" # The install partition
+ROOT_PARTITION: "{{ volume_drive }}p1" # The install partition
 volume_size: 4
-volume_drive: /dev/xvdf
+volume_drive: /dev/nvme1n1
 WRITE_ROOT: /mnt/wroot
 READ_ROOT: /mnt/squashfs
 INSTALL_ROOT: /mnt/inst_root

--- a/playbooks/roles/build-disk/defaults/main.yml
+++ b/playbooks/roles/build-disk/defaults/main.yml
@@ -7,6 +7,7 @@ vyos_key_local: /tmp/vyos-release.gpg
 CD_ROOT: /mnt/cdrom
 CD_SQUASH_ROOT: /mnt/cdsquash
 SQUASHFS_IMAGE: "{{ CD_ROOT }}/live/filesystem.squashfs"
+temp_ssm: "/tmp/ssm"
 
 ROOT_FSTYPE: ext4
 ROOT_PARTITION: "{{ volume_drive }}p1" # The install partition

--- a/playbooks/roles/build-disk/tasks/main.yml
+++ b/playbooks/roles/build-disk/tasks/main.yml
@@ -9,6 +9,17 @@
     path: "/etc/apt/sources.list.d"
     state: absent
 
+- name: Creating SSM directory in tmp
+  file:
+    path: "{{ temp_ssm }}"
+    state: directory
+
+- name: Download SSM
+  get_url:
+    url: https://s3.eu-central-1.amazonaws.com/amazon-ssm-eu-central-1/latest/debian_amd64/amazon-ssm-agent.deb
+    dest: "{{ temp_ssm }}/amazon-ssm-agent.deb"
+    mode: 0644
+
 - name: update sources.list
   copy:
     src: "files/sources.list"
@@ -200,6 +211,16 @@
     dest: "{{ WRITE_ROOT }}/persistence.conf"
     mode: 0644
 
+- name: Copy SSM package
+  copy:
+    src: "{{ temp_ssm }}/amazon-ssm-agent.deb"
+    dest: "{{ INSTALL_ROOT }}/tmp/amazon-ssm-agent.deb"
+    mode: 0644
+    remote_src: true
+
+- name: Install SSM
+  command: chroot {{ INSTALL_ROOT }} dpkg -i /tmp/amazon-ssm-agent.deb
+
 # ---- Unmount all mounts ----
 - name: Unmount {{ INSTALL_ROOT }}/boot
   mount:
@@ -250,4 +271,3 @@
     src: "{{ vyos_iso_local }}"
     fstype: iso9660
     state: unmounted
-

--- a/playbooks/roles/build-disk/tasks/main.yml
+++ b/playbooks/roles/build-disk/tasks/main.yml
@@ -27,9 +27,6 @@
       - gnupg
     state: present
 
-- name: Load aufs module
-  shell: modprobe aufs
-
 # ---- Set up the specified ISO release ----
 
 # - name: Fetch VyOS ISO GPG signature
@@ -149,8 +146,8 @@
   mount:
     name: "{{ INSTALL_ROOT }}"
     src: none
-    fstype: aufs
-    opts: "noatime,dirs={{ RW_DIR.path }}=rw:{{ READ_ROOT }}=rr"
+    fstype: overlay
+    opts: "noatime,upperdir={{ RW_DIR.path }},lowerdir={{ READ_ROOT }},workdir={{ WRITE_ROOT }}/boot/{{ version_string.stdout }}/work/work"
     state: mounted
 
 # ---- Post image installation tasks ----

--- a/playbooks/roles/build-vyos-ami/defaults/main.yml
+++ b/playbooks/roles/build-vyos-ami/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for build-vyos-ami
 ec2_region: us-east-1
-ebs_drive: /dev/sdf
+ebs_drive: xvdf

--- a/playbooks/roles/build-vyos-ami/vars/main.yml
+++ b/playbooks/roles/build-vyos-ami/vars/main.yml
@@ -6,4 +6,4 @@ ami_name: VyOS (HVM) {{ version_string }}
 ami_description: The VyOS AMI is an EBS-backed, HVM image. It is an open-source Linux-based network operating system that provides software-based network routing, firewall, and VPN functionality.
 ami_architecture: x86_64
 ami_virtualization_type: hvm
-ami_root_device_name: /dev/xvda
+ami_root_device_name: /dev/sda1

--- a/playbooks/roles/provision-ec2-instance/defaults/main.yml
+++ b/playbooks/roles/provision-ec2-instance/defaults/main.yml
@@ -4,16 +4,16 @@ key_pair_name: vyos-build-ami
 ec2_region: us-east-1
 temp_folder: "{{ playbook_dir }}/files/ssh-keys"
 key_pair_file: "{{ temp_folder }}/{{ key_pair_name }}.pem"
-instance_type: t2.micro
+instance_type: t3.micro
 
 base_image:
   debian_aws_account_id: "379101102735"
-  name: "debian-jessie-amd64-hvm-*"
+  name: "debian-stretch-hvm-x86_64-*"
   architecture: "x86_64"
   hypervisor: "xen"
   root_device_type: "ebs"
 
 placeholder: vyos-build-ami
 volume_size: 4
-volume_drive: /dev/xvdf
+volume_drive: /dev/nvme1n1
 ansible_ssh_private_key_file: "{{ key_pair_file }}"

--- a/playbooks/roles/provision-ec2-instance/tasks/main.yml
+++ b/playbooks/roles/provision-ec2-instance/tasks/main.yml
@@ -94,7 +94,7 @@
     - AWS
 
 #Look up the AMI id to use based on a search
-- name: Look up Debian Jessie AMI
+- name: Look up Debian Stretch AMI
   ec2_ami_facts:
     owners: "{{ base_image.debian_aws_account_id }}"
     region: "{{ ec2_region }}"
@@ -109,13 +109,18 @@
     - aws
     - AWS
 
+- name: Now get the latest one
+  set_fact:
+    latest_ami: >
+      {{ debian_ami.images | sort(attribute='creation_date') | last }}
+
 #---- Launch EC2 instance ----
 - name: Launch an EC2 instance
   ec2:
     key_name: "{{ key_pair_name }}"
     assign_public_ip: True
     vpc_subnet_id: "{{ vpc_subnets.subnets[0].subnet_id }}"
-    image: "{{ debian_ami.images[0].image_id }}"
+    image: "{{ latest_ami.image_id }}"
     instance_type: "{{ instance_type }}"
     region: "{{ ec2_region }}"
     group_id: "{{ security_group.group_id  }}"
@@ -124,7 +129,7 @@
       Name: "{{ placeholder }}"
       Type: "VyOS"
     volumes:
-      - device_name: /dev/sdf
+      - device_name: xvdf
         volume_type: gp2
         volume_size: "{{ volume_size }}"
         delete_on_termination: True


### PR DESCRIPTION
This pull request will:
- Use the latest generation instance type (t3.micro)
- Use Debian Jessie instead of Stretch as base
- Install SSM agent