### PR TITLE
Use ec2_*_info instead of _facts

### DIFF
--- a/playbooks/roles/ec2-cleanup/tasks/main.yml
+++ b/playbooks/roles/ec2-cleanup/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for ec2-cleanup
 - name: Grab instance IDs
-  ec2_instance_facts:
+  ec2_instance_info:
     filters:
       instance-state-name:  [ "shutting-down", "stopping", "stopped","running" ] 
       "tag:Name": "vyos-build-ami"

--- a/playbooks/roles/provision-ec2-instance/tasks/main.yml
+++ b/playbooks/roles/provision-ec2-instance/tasks/main.yml
@@ -56,7 +56,7 @@
     - AWS
 
 - name: Find the default VPC
-  ec2_vpc_net_facts:
+  ec2_vpc_net_info:
     region: "{{ ec2_region }}"
     filters:
       isDefault: "true"
@@ -66,7 +66,7 @@
     - AWS
 
 - name: Find the default VPC subnet
-  ec2_vpc_subnet_facts:
+  ec2_vpc_subnet_info:
     region: "{{ ec2_region }}"
     filters:
       "vpc-id": "{{ vpc_nets.vpcs[0].vpc_id }}"
@@ -95,7 +95,7 @@
 
 #Look up the AMI id to use based on a search
 - name: Look up Debian Jessie AMI
-  ec2_ami_facts:
+  ec2_ami_info:
     owners: "{{ base_image.debian_aws_account_id }}"
     region: "{{ ec2_region }}"
     filters:


### PR DESCRIPTION
It seems that, on newer versions of Ansible, it's not possible to use `ec2_*_facts` anymore.
```
(env) root@ip-172-31-2-7:~/build-ami# ansible --version
ansible [core 2.13.1]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /root/build-ami/env/lib/python3.9/site-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /root/build-ami/env/bin/ansible
  python version = 3.9.2 (default, Feb 28 2021, 17:03:44) [GCC 10.2.1 20210110]
  jinja version = 3.1.2
  libyaml = True
```